### PR TITLE
Expire schedule according to display time

### DIFF
--- a/dataAccessObjects.py
+++ b/dataAccessObjects.py
@@ -282,6 +282,10 @@ class ScheduleDao(DefaultDao):
     def updateNewIdSchedule(self,scheNewId,scheSn):
         sql = "UPDATE schedule SET sche_id='{scheId}' WHERE sche_sn={scheSn}".format(scheId=scheNewId,scheSn=scheSn)
         self.db.cmd(sql)
+    
+    def getDisplayTime(self,scheSn):
+        sql = "SELECT sche_display_time FROM schedule WHERE sche_sn={scheSn}".format(scheSn=scheSn)
+        return self.queryOneValue(sql)
 
 class ImageDao(DataManipulateDao):
     dataName = 'img'


### PR DESCRIPTION
Currently the board will expired an activity every 3 seconds
(the moment `raw_time >= alarm_check_remain_schedule`)
This PR adds display time check and expire displaying content according to its displaying time.
